### PR TITLE
Adding utilities for config conversions

### DIFF
--- a/healthcheck/healthcheck.go
+++ b/healthcheck/healthcheck.go
@@ -29,21 +29,21 @@ type CanBeHealthy interface {
 }
 
 type Healthcheck struct {
-	canPassYet    bool              `yaml:"-"`
-	runCount      uint64            `yaml:"-"`
-	Type          string            `yaml:"type"`
-	Destination   string            `yaml:"destination"`
-	isHealthy     bool              `yaml:"-"`
-	Rise          uint              `yaml:"rise"`
-	Fall          uint              `yaml:"fall"`
-	Every         uint              `yaml:"every"`
-	History       []bool            `yaml:"-"`
-	Config        map[string]string `yaml:"config"`
-	healthchecker HealthChecker     `yaml:"-"`
-	isRunning     bool              `yaml:"-"`
-	quitChan      chan<- bool       `yaml:"-"`
-	hasQuitChan   <-chan bool       `yaml:"-"`
-	listeners     []chan<- bool     `yaml:"-"`
+	canPassYet    bool                   `yaml:"-"`
+	runCount      uint64                 `yaml:"-"`
+	Type          string                 `yaml:"type"`
+	Destination   string                 `yaml:"destination"`
+	isHealthy     bool                   `yaml:"-"`
+	Rise          uint                   `yaml:"rise"`
+	Fall          uint                   `yaml:"fall"`
+	Every         uint                   `yaml:"every"`
+	History       []bool                 `yaml:"-"`
+	Config        map[string]interface{} `yaml:"config"`
+	healthchecker HealthChecker          `yaml:"-"`
+	isRunning     bool                   `yaml:"-"`
+	quitChan      chan<- bool            `yaml:"-"`
+	hasQuitChan   <-chan bool            `yaml:"-"`
+	listeners     []chan<- bool          `yaml:"-"`
 }
 
 func (h *Healthcheck) NewWithDestination(destination string) (*Healthcheck, error) {
@@ -136,7 +136,7 @@ func (h *Healthcheck) PerformHealthcheck() {
 
 func (h *Healthcheck) Validate(name string, remote bool) error {
 	if h.Config == nil {
-		h.Config = make(map[string]string)
+		h.Config = make(map[string]interface{})
 	}
 	if h.Rise == 0 {
 		h.Rise = 2

--- a/healthcheck/tcp.go
+++ b/healthcheck/tcp.go
@@ -4,8 +4,9 @@ import (
 	"errors"
 	"fmt"
 	log "github.com/Sirupsen/logrus"
+	utils "github.com/bobtfish/AWSnycast/utils"
+	"github.com/hashicorp/go-multierror"
 	"net"
-	"strconv"
 	"strings"
 	"time"
 
@@ -142,52 +143,60 @@ func (h TcpHealthCheck) Healthcheck() bool {
 }
 
 func TcpConstructor(h Healthcheck) (HealthChecker, error) {
-	if _, ok := h.Config["port"]; !ok {
-		return TcpHealthCheck{}, errors.New("'port' not defined in tcp healthcheck config to " + h.Destination)
-	}
 
+	var result *multierror.Error
 	hc := TcpHealthCheck{
 		Destination: h.Destination,
-		Port:        h.Config["port"],
 	}
+
+	if val, ok := h.Config["port"]; ok {
+		hc.Port = utils.GetAsString(val)
+	} else {
+		result = multierror.Append(result, errors.New("'port' not defined in tcp healthcheck config to "+h.Destination))
+	}
+
 	if v, ok := h.Config["expect"]; ok {
-		hc.Expect = v
+		hc.Expect = v.(string)
 	}
+
 	if v, ok := h.Config["send"]; ok {
-		hc.Send = v
+		hc.Send = v.(string)
 	}
 
 	if val, exists := h.Config["ssl"]; exists {
-		ssl, er := strconv.ParseBool(val)
+		ssl, er := utils.GetAsBool(val, false)
 		if er != nil {
-			return TcpHealthCheck{}, errors.New("'ssl' has to be true or false, input: " + val)
+			result = multierror.Append(result, errors.New("'ssl' has to be true or false"))
+		} else {
+			hc.TLS = ssl
 		}
-		hc.TLS = ssl
 
 		if val, exists := h.Config["certPath"]; exists {
-			x509, err := ioutil.ReadFile(val)
+			x509, err := ioutil.ReadFile(val.(string))
 			if err != nil {
-				return TcpHealthCheck{}, errors.New("'cert' refers to a file that can not be parsed" + val)
+				result = multierror.Append(result, errors.New("'cert' refers to a file that can not be parsed"))
+			} else {
+				hc.x509 = x509
 			}
-			hc.x509 = x509
 		}
 
 		if val, exists := h.Config["cert"]; exists {
-			x509 := []byte(val)
+			x509 := []byte(val.(string))
 			hc.x509 = x509
 		}
 
 		if val, exists := h.Config["skipVerify"]; exists {
-			skipVerify, err := strconv.ParseBool(val)
+			skipVerify, err := utils.GetAsBool(val, false)
 			if err != nil {
-				return TcpHealthCheck{}, errors.New("'skipVerify' has to be true or false, input: " + val)
+				result = multierror.Append(result, errors.New("'skipVerify' has to be true or false, input"))
+			} else {
+				hc.SkipVerify = skipVerify
 			}
-			hc.SkipVerify = skipVerify
 		}
 
 		if val, exists := h.Config["serverName"]; exists {
-			hc.ServerName = string(val)
+			hc.ServerName = val.(string)
 		}
 	}
-	return hc, nil
+	return hc, result.ErrorOrNil()
 }

--- a/healthcheck/tcp_test.go
+++ b/healthcheck/tcp_test.go
@@ -5,6 +5,7 @@ import (
 	"crypto/x509"
 	"fmt"
 	log "github.com/Sirupsen/logrus"
+	"github.com/bobtfish/AWSnycast/testhelpers"
 	"github.com/stretchr/testify/assert"
 	"io/ioutil"
 	"net"
@@ -24,7 +25,7 @@ func TestHealthcheckTcpNoPort(t *testing.T) {
 	h.Validate("foo", false)
 	err := h.Setup()
 	if assert.NotNil(t, err) {
-		assert.Equal(t, err.Error(), "'port' not defined in tcp healthcheck config to 127.0.0.1")
+		testhelpers.CheckOneMultiError(t, err, "'port' not defined in tcp healthcheck config to 127.0.0.1")
 	}
 }
 

--- a/healthcheck/tcp_test.go
+++ b/healthcheck/tcp_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestHealthcheckTcpNoPort(t *testing.T) {
-	c := make(map[string]string)
+	c := make(map[string]interface{})
 	c["send"] = "HEAD / HTTP/1.0\r\n\r\n"
 	c["expect"] = "200 OK"
 	h := Healthcheck{
@@ -55,7 +55,7 @@ func TestHealthcheckTcp(t *testing.T) {
 			}
 		}()
 		<-ready
-		c := make(map[string]string)
+		c := make(map[string]interface{})
 		c["port"] = fmt.Sprintf("%d", port)
 		c["send"] = "HEAD / HTTP/1.0\r\n\r\n"
 		c["expect"] = "200 OK"
@@ -106,7 +106,7 @@ func TestHealthcheckTcpFail(t *testing.T) {
 		}
 	}()
 	<-ready
-	c := make(map[string]string)
+	c := make(map[string]interface{})
 	c["port"] = fmt.Sprintf("%d", port)
 	c["send"] = "HEAD / HTTP/1.0\r\n\r\n"
 	c["expect"] = "200 OK"
@@ -132,7 +132,7 @@ func TestHealthcheckTcpClosed(t *testing.T) {
 	if assert.Nil(t, err) {
 		port := ln.Addr().(*net.TCPAddr).Port
 		ln.Close() // Close the port again before running healthcheck
-		c := make(map[string]string)
+		c := make(map[string]interface{})
 		c["port"] = fmt.Sprintf("%d", port)
 		c["send"] = "HEAD / HTTP/1.0\r\n\r\n"
 		c["expect"] = "200 OK"
@@ -171,7 +171,7 @@ func TestHealthcheckTcpFailClientClose(t *testing.T) {
 			}
 		}()
 		<-ready
-		c := make(map[string]string)
+		c := make(map[string]interface{})
 		c["port"] = fmt.Sprintf("%d", port)
 		c["send"] = "HEAD / HTTP/1.0\r\n\r\n"
 		c["expect"] = "200 OK"
@@ -219,7 +219,7 @@ func TestHealthcheckTcpNoExpect(t *testing.T) {
 			}
 		}()
 		<-ready
-		c := make(map[string]string)
+		c := make(map[string]interface{})
 		c["port"] = fmt.Sprintf("%d", port)
 		c["send"] = "HEAD / HTTP/1.0\r\n\r\n"
 		h := Healthcheck{
@@ -261,7 +261,7 @@ func TestHealthcheckTcpNoSendOrExpect(t *testing.T) {
 		}
 	}()
 	<-ready
-	c := make(map[string]string)
+	c := make(map[string]interface{})
 	c["port"] = fmt.Sprintf("%d", port)
 	h := Healthcheck{
 		Type:        "tcp",
@@ -301,7 +301,7 @@ func TestHealthcheckTcpNoSend(t *testing.T) {
 			}
 		}()
 		<-ready
-		c := make(map[string]string)
+		c := make(map[string]interface{})
 		c["port"] = fmt.Sprintf("%d", port)
 		c["expect"] = "200 OK"
 		h := Healthcheck{
@@ -422,7 +422,7 @@ func TestHealthcheckTcpTLS(t *testing.T) {
 			}
 		}()
 		<-ready
-		c := make(map[string]string)
+		c := make(map[string]interface{})
 		c["port"] = fmt.Sprintf("%d", port)
 		c["send"] = "HEAD / HTTP/1.0\r\n\r\n"
 		c["expect"] = "200 OK"
@@ -482,7 +482,7 @@ func TestHealthcheckTcpTLSSkipVerify(t *testing.T) {
 			}
 		}()
 		<-ready
-		c := make(map[string]string)
+		c := make(map[string]interface{})
 		c["port"] = fmt.Sprintf("%d", port)
 		c["send"] = "HEAD / HTTP/1.0\r\n\r\n"
 		c["expect"] = "200 OK"
@@ -540,7 +540,7 @@ func TestHealthcheckTcpTLSEmptyExpect(t *testing.T) {
 			}
 		}()
 		<-ready
-		c := make(map[string]string)
+		c := make(map[string]interface{})
 		c["port"] = fmt.Sprintf("%d", port)
 		c["send"] = "HEAD / HTTP/1.0\r\n\r\n"
 		c["expect"] = ""
@@ -565,7 +565,7 @@ func TestHealthcheckTcpTLSEmptyExpect(t *testing.T) {
 }
 
 func TestHealthcheckTcpTLSFailedParse(t *testing.T) {
-	c := make(map[string]string)
+	c := make(map[string]interface{})
 	c["port"] = "0"
 	c["send"] = "HEAD / HTTP/1.0\r\n\r\n"
 	c["expect"] = "200 OK"
@@ -621,7 +621,7 @@ func TestHealthcheckTcpTLSFailedread(t *testing.T) {
 			}
 		}()
 		<-ready
-		c := make(map[string]string)
+		c := make(map[string]interface{})
 		c["port"] = fmt.Sprintf("%d", port)
 		c["send"] = "HEAD / HTTP/1.0\r\n\r\n"
 		c["expect"] = "200 OK"
@@ -646,7 +646,7 @@ func TestHealthcheckTcpTLSFailedread(t *testing.T) {
 }
 
 func TestHealthcheckTcpTLSFailedConnet(t *testing.T) {
-	c := make(map[string]string)
+	c := make(map[string]interface{})
 	c["port"] = "hello"
 	c["ssl"] = "true"
 
@@ -664,7 +664,7 @@ func TestHealthcheckTcpTLSFailedConnet(t *testing.T) {
 }
 
 func TestHealthcheckTcpTLSFailedParseSkipVerify(t *testing.T) {
-	c := make(map[string]string)
+	c := make(map[string]interface{})
 	c["port"] = "0"
 	c["skipVerify"] = "bye"
 	c["ssl"] = "true"
@@ -679,7 +679,7 @@ func TestHealthcheckTcpTLSFailedParseSkipVerify(t *testing.T) {
 }
 
 func TestHealthcheckTcpTLSFailedParseSSL(t *testing.T) {
-	c := make(map[string]string)
+	c := make(map[string]interface{})
 	c["port"] = "0"
 	c["ssl"] = "bye"
 
@@ -693,7 +693,7 @@ func TestHealthcheckTcpTLSFailedParseSSL(t *testing.T) {
 }
 
 func TestHealthcheckTcpTLSFailedCertPath(t *testing.T) {
-	c := make(map[string]string)
+	c := make(map[string]interface{})
 	c["port"] = "0"
 	c["certPath"] = "fakeFile"
 	c["ssl"] = "true"
@@ -708,7 +708,7 @@ func TestHealthcheckTcpTLSFailedCertPath(t *testing.T) {
 }
 
 func TestHealthcheckTcpTLSCertPath(t *testing.T) {
-	c := make(map[string]string)
+	c := make(map[string]interface{})
 	c["port"] = "0"
 	c["certPath"] = tmpTestFakeFile
 	c["ssl"] = "true"

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -1,0 +1,141 @@
+package utils
+
+import (
+	"errors"
+	"gopkg.in/yaml.v2"
+	"reflect"
+	"strconv"
+)
+
+// GetAsBool parses a string to a bool or returns the bool if bool is passed in
+func GetAsBool(value interface{}, defaultValue bool) (result bool, err error) {
+	result = defaultValue
+
+	switch value.(type) {
+	case string:
+		fromString, e := strconv.ParseBool(value.(string))
+		if e != nil {
+			err = errors.New("Failed to convert value to a bool. Falling back to default")
+			result = defaultValue
+		} else {
+			result = fromString
+		}
+	case bool:
+		result = value.(bool)
+	}
+
+	return
+}
+
+// GetAsFloat parses a string to a float or returns the float if float is passed in
+func GetAsFloat(value interface{}, defaultValue float64) (result float64, err error) {
+	result = defaultValue
+
+	switch value.(type) {
+	case string:
+		fromString, e := strconv.ParseFloat(value.(string), 64)
+		if e != nil {
+			err = errors.New("Failed to convert value to a bool. Falling back to default")
+			result = defaultValue
+		} else {
+			result = fromString
+		}
+	case float64:
+		result = value.(float64)
+	}
+
+	return
+}
+
+// GetAsInt parses a string/float to an int or returns the int if int is passed in
+func GetAsInt(value interface{}, defaultValue int) (result int, err error) {
+	result = defaultValue
+
+	switch value.(type) {
+	case string:
+		fromString, e := strconv.ParseInt(value.(string), 10, 64)
+		if e == nil {
+			result = int(fromString)
+		} else {
+			err = errors.New("Failed to convert value to an int")
+		}
+	case int:
+		result = value.(int)
+	case int32:
+		result = int(value.(int32))
+	case int64:
+		result = int(value.(int64))
+	case float64:
+		result = int(value.(float64))
+	}
+
+	return
+}
+
+// GetAsString parses a int/float to a string or returns the string if string is passed in
+func GetAsString(value interface{}) (result string) {
+	result = ""
+
+	switch value.(type) {
+	case string:
+		result = value.(string)
+	case int:
+		result = strconv.Itoa(value.(int))
+	case float64:
+		result = strconv.FormatFloat(value.(float64), 'G', -1, 64)
+	}
+
+	return
+}
+
+// GetAsMap parses a string to a map[string]string
+func GetAsMap(value interface{}) (result map[string]string, err error) {
+	result = make(map[string]string)
+
+	switch value.(type) {
+	case string:
+		e := yaml.Unmarshal([]byte(value.(string)), &result)
+		if e != nil {
+			err = errors.New("Failed to convert value to a map")
+		}
+	case map[string]interface{}:
+		temp := value.(map[string]interface{})
+		for k, v := range temp {
+			if str, ok := v.(string); ok {
+				result[k] = str
+			} else {
+				err = errors.New("Expected a string but got" + reflect.TypeOf(value).Name())
+			}
+		}
+	case map[string]string:
+		result = value.(map[string]string)
+	default:
+		err = errors.New("Expected a string but got" + reflect.TypeOf(value).Name())
+	}
+
+	return
+}
+
+// GetAsSlice : Parses a yaml array string to []string
+func GetAsSlice(value interface{}) (result []string, err error) {
+	result = []string{}
+
+	switch realValue := value.(type) {
+	case string:
+		e := yaml.Unmarshal([]byte(realValue), &result)
+		if e != nil {
+			err = errors.New("Failed to convert string:" + realValue + "to a []string")
+		}
+	case []string:
+		result = realValue
+	case []interface{}:
+		result = make([]string, len(realValue))
+		for i, value := range realValue {
+			result[i] = value.(string)
+		}
+	default:
+		err = errors.New("Expected a string array but got" + reflect.TypeOf(realValue).Name() + ". Returning empty slice!")
+	}
+
+	return
+}

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -79,7 +79,7 @@ func TestGetAsMap(t *testing.T) {
 		"region":     "uswest1-devc",
 	}
 	actualValue, err := GetAsMap(stringToParse)
-	assert.Equal(actualValue, expectedValue)
+	assert.Equal(t, actualValue, expectedValue)
 
 	// Test if map[string]interface{} can be converted to map[string]string
 	interfaceMapToParse := make(map[string]interface{})
@@ -87,7 +87,7 @@ func TestGetAsMap(t *testing.T) {
 	interfaceMapToParse["alice"] = "bob"
 
 	actualValue, err = GetAsMap(interfaceMapToParse)
-	assert.Equal(actualValue, expectedValue)
+	assert.Equal(t, actualValue, expectedValue)
 
 	actualValue, err = GetAsMap(123)
 	assert.NotNil(t, err)
@@ -98,11 +98,11 @@ func TestGetAsSlice(t *testing.T) {
 	stringToParse := "[\"baz\", \"bat\"]"
 	expectedValue := []string{"baz", "bat"}
 	actualValue, err := GetAsSlice(stringToParse)
-	assert.Equal(actualValue, expectedValue)
+	assert.Equal(t, actualValue, expectedValue)
 
 	sliceToParse := []string{"baz", "bat"}
 	actualValue, err = GetAsSlice(sliceToParse)
-	assert.Equal(actualValue, expectedValue)
+	assert.Equal(t, actualValue, expectedValue)
 
 	actualValue, err = GetAsSlice(123)
 	assert.NotNil(t, err)

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -1,0 +1,137 @@
+package utils
+
+import (
+	"github.com/stretchr/testify/assert"
+	"gopkg.in/yaml.v2"
+	"testing"
+)
+
+func TestGetBool(t *testing.T) {
+	assert := assert.New(t)
+
+	val, err := config.GetAsBool("false", true)
+	assert.Equal(val, false)
+	assert.Nil(err)
+
+	val, err = config.GetAsBool("notabool", false)
+	assert.Equal(val, false)
+	assert.NotNil(err)
+
+	val, err = config.GetAsBool(true, false)
+	assert.Equal(val, true)
+	assert.Nil(err)
+
+	val, err = config.GetAsBool("True", false)
+	assert.Equal(val, true)
+	assert.Nil(err)
+}
+
+func TestGetInt(t *testing.T) {
+	assert := assert.New(t)
+
+	val, err := config.GetAsInt("10", 123)
+	assert.Equal(val, 10)
+	assert.Nil(err)
+
+	val, err = config.GetAsInt("notanint", 123)
+	assert.Equal(val, 123)
+	assert.NotNil(err)
+
+	val, err = config.GetAsInt(12.123, 123)
+	assert.Equal(val, 12)
+	assert.Nil(err)
+
+	val, err = config.GetAsInt(12, 123)
+	assert.Equal(val, 12)
+	assert.Nil(err)
+}
+
+func TestGetFloat(t *testing.T) {
+	assert := assert.New(t)
+
+	val, err := config.GetAsFloat("10", 123)
+	assert.Equal(val, 10.0)
+	assert.Nil(err)
+
+	val, err = config.GetAsFloat("10.21", 123)
+	assert.Equal(val, 10.21)
+	assert.Nil(err)
+
+	val, err = confir.GetAsFloat("notafloat", 123)
+	assert.Equal(val, 123.0)
+	assert.NotNil(err)
+
+	val, err = config.GetAsFloat(12.123, 123)
+	assert.Equal(val, 12.123)
+	assert.Nil(err)
+}
+
+func TestGetString(t *testing.T) {
+	assert := assert.New(t)
+
+	val := config.GetAsString("10")
+	assert.Equal(val, "10")
+
+	val = config.GetAsString(10)
+	assert.equal(val, "10")
+
+	val = config.GetAsString(10.123)
+	assert.equal(val, "10.123")
+}
+
+func TestGetAsMap(t *testing.T) {
+	assert := assert.New(t)
+
+	// Test if string can be converted to map[string]string
+	stringToParse := "{\"foor\" : \"bar\", \"alice\":\"bob\"}"
+	expectedValue := map[string]string{
+		"runtimeenv": "dev",
+		"region":     "uswest1-devc",
+	}
+	assert.Equal(config.GetAsMap(stringToParse), expectedValue)
+
+	// Test if map[string]interface{} can be converted to map[string]string
+	interfaceMapToParse := make(map[string]interface{})
+	interfaceMapToParse["foo"] = "bar"
+	interfaceMapToParse["alice"] = "bob"
+
+	actualValue, err := config.GetAsMap(interfaceMapToParse)
+	assert.Equal(actualValue, expectedValue)
+
+	actualValue, err = config.GetAsMap(123)
+	assert.NotNil(err)
+}
+
+func TestGetAsSlice(t *testing.T) {
+	assert := assert.New(t)
+
+	// Test if string array can be converted to []string
+	stringToParse := "[\"baz\", \"bat\"]"
+	expectedValue := []string{"baz", "bat"}
+	assert.Equal(config.GetAsSlice(stringToParse), expectedValue)
+
+	sliceToParse := []string{"baz", "bat"}
+	actualValue, err := config.GetAsSlice(sliceToParse)
+	assert.Equal(actualValue, expectedValue)
+
+	actualValue, err = config.GetAsSlice(123)
+	assert.NotNil(err)
+}
+
+func TestGetAsSliceFromYAML(t *testing.T) {
+	var data interface{}
+	yamlString := []byte(`{"listOfStrings": ["a", "b", "c"]}`)
+
+	err := yaml.Unmarshal(yamlString, &data)
+	assert.Nil(t, err)
+
+	if err == nil {
+		temp := data.(map[string]interface{})
+
+		res, err := config.GetAsSlice(temp["listOfStrings"])
+		assert.Equal(t, []string{"a", "b", "c"}, res)
+
+		res, err = config.GetAsSlice(123)
+		assert.NotNil(err)
+	}
+}

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	utils "github.com/bobtfish/AWSnycast/utils"
 	"github.com/stretchr/testify/assert"
 	"gopkg.in/yaml.v2"
 	"testing"
@@ -9,19 +10,19 @@ import (
 func TestGetBool(t *testing.T) {
 	assert := assert.New(t)
 
-	val, err := config.GetAsBool("false", true)
+	val, err := utils.GetAsBool("false", true)
 	assert.Equal(val, false)
 	assert.Nil(err)
 
-	val, err = config.GetAsBool("notabool", false)
+	val, err = utils.GetAsBool("notabool", false)
 	assert.Equal(val, false)
 	assert.NotNil(err)
 
-	val, err = config.GetAsBool(true, false)
+	val, err = utils.GetAsBool(true, false)
 	assert.Equal(val, true)
 	assert.Nil(err)
 
-	val, err = config.GetAsBool("True", false)
+	val, err = utils.GetAsBool("True", false)
 	assert.Equal(val, true)
 	assert.Nil(err)
 }
@@ -29,19 +30,19 @@ func TestGetBool(t *testing.T) {
 func TestGetInt(t *testing.T) {
 	assert := assert.New(t)
 
-	val, err := config.GetAsInt("10", 123)
+	val, err := utils.GetAsInt("10", 123)
 	assert.Equal(val, 10)
 	assert.Nil(err)
 
-	val, err = config.GetAsInt("notanint", 123)
+	val, err = utils.GetAsInt("notanint", 123)
 	assert.Equal(val, 123)
 	assert.NotNil(err)
 
-	val, err = config.GetAsInt(12.123, 123)
+	val, err = utils.GetAsInt(12.123, 123)
 	assert.Equal(val, 12)
 	assert.Nil(err)
 
-	val, err = config.GetAsInt(12, 123)
+	val, err = utils.GetAsInt(12, 123)
 	assert.Equal(val, 12)
 	assert.Nil(err)
 }
@@ -49,11 +50,11 @@ func TestGetInt(t *testing.T) {
 func TestGetFloat(t *testing.T) {
 	assert := assert.New(t)
 
-	val, err := config.GetAsFloat("10", 123)
+	val, err := utils.GetAsFloat("10", 123)
 	assert.Equal(val, 10.0)
 	assert.Nil(err)
 
-	val, err = config.GetAsFloat("10.21", 123)
+	val, err = utils.GetAsFloat("10.21", 123)
 	assert.Equal(val, 10.21)
 	assert.Nil(err)
 
@@ -61,7 +62,7 @@ func TestGetFloat(t *testing.T) {
 	assert.Equal(val, 123.0)
 	assert.NotNil(err)
 
-	val, err = config.GetAsFloat(12.123, 123)
+	val, err = utils.GetAsFloat(12.123, 123)
 	assert.Equal(val, 12.123)
 	assert.Nil(err)
 }
@@ -69,13 +70,13 @@ func TestGetFloat(t *testing.T) {
 func TestGetString(t *testing.T) {
 	assert := assert.New(t)
 
-	val := config.GetAsString("10")
+	val := utils.GetAsString("10")
 	assert.Equal(val, "10")
 
-	val = config.GetAsString(10)
+	val = utils.GetAsString(10)
 	assert.equal(val, "10")
 
-	val = config.GetAsString(10.123)
+	val = utils.GetAsString(10.123)
 	assert.equal(val, "10.123")
 }
 
@@ -88,17 +89,17 @@ func TestGetAsMap(t *testing.T) {
 		"runtimeenv": "dev",
 		"region":     "uswest1-devc",
 	}
-	assert.Equal(config.GetAsMap(stringToParse), expectedValue)
+	assert.Equal(utils.GetAsMap(stringToParse), expectedValue)
 
 	// Test if map[string]interface{} can be converted to map[string]string
 	interfaceMapToParse := make(map[string]interface{})
 	interfaceMapToParse["foo"] = "bar"
 	interfaceMapToParse["alice"] = "bob"
 
-	actualValue, err := config.GetAsMap(interfaceMapToParse)
+	actualValue, err := utils.GetAsMap(interfaceMapToParse)
 	assert.Equal(actualValue, expectedValue)
 
-	actualValue, err = config.GetAsMap(123)
+	actualValue, err = utils.GetAsMap(123)
 	assert.NotNil(err)
 }
 
@@ -108,13 +109,13 @@ func TestGetAsSlice(t *testing.T) {
 	// Test if string array can be converted to []string
 	stringToParse := "[\"baz\", \"bat\"]"
 	expectedValue := []string{"baz", "bat"}
-	assert.Equal(config.GetAsSlice(stringToParse), expectedValue)
+	assert.Equal(utils.GetAsSlice(stringToParse), expectedValue)
 
 	sliceToParse := []string{"baz", "bat"}
-	actualValue, err := config.GetAsSlice(sliceToParse)
+	actualValue, err := utils.GetAsSlice(sliceToParse)
 	assert.Equal(actualValue, expectedValue)
 
-	actualValue, err = config.GetAsSlice(123)
+	actualValue, err = utils.GetAsSlice(123)
 	assert.NotNil(err)
 }
 
@@ -128,10 +129,10 @@ func TestGetAsSliceFromYAML(t *testing.T) {
 	if err == nil {
 		temp := data.(map[string]interface{})
 
-		res, err := config.GetAsSlice(temp["listOfStrings"])
+		res, err := utils.GetAsSlice(temp["listOfStrings"])
 		assert.Equal(t, []string{"a", "b", "c"}, res)
 
-		res, err = config.GetAsSlice(123)
+		res, err = utils.GetAsSlice(123)
 		assert.NotNil(err)
 	}
 }

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -9,19 +9,19 @@ import (
 func TestGetBool(t *testing.T) {
 	assert := assert.New(t)
 
-	val, err := utils.GetAsBool("false", true)
+	val, err := GetAsBool("false", true)
 	assert.Equal(val, false)
 	assert.Nil(err)
 
-	val, err = utils.GetAsBool("notabool", false)
+	val, err = GetAsBool("notabool", false)
 	assert.Equal(val, false)
 	assert.NotNil(err)
 
-	val, err = utils.GetAsBool(true, false)
+	val, err = GetAsBool(true, false)
 	assert.Equal(val, true)
 	assert.Nil(err)
 
-	val, err = utils.GetAsBool("True", false)
+	val, err = GetAsBool("True", false)
 	assert.Equal(val, true)
 	assert.Nil(err)
 }
@@ -29,19 +29,19 @@ func TestGetBool(t *testing.T) {
 func TestGetInt(t *testing.T) {
 	assert := assert.New(t)
 
-	val, err := utils.GetAsInt("10", 123)
+	val, err := GetAsInt("10", 123)
 	assert.Equal(val, 10)
 	assert.Nil(err)
 
-	val, err = utils.GetAsInt("notanint", 123)
+	val, err = GetAsInt("notanint", 123)
 	assert.Equal(val, 123)
 	assert.NotNil(err)
 
-	val, err = utils.GetAsInt(12.123, 123)
+	val, err = GetAsInt(12.123, 123)
 	assert.Equal(val, 12)
 	assert.Nil(err)
 
-	val, err = utils.GetAsInt(12, 123)
+	val, err = GetAsInt(12, 123)
 	assert.Equal(val, 12)
 	assert.Nil(err)
 }
@@ -49,11 +49,11 @@ func TestGetInt(t *testing.T) {
 func TestGetFloat(t *testing.T) {
 	assert := assert.New(t)
 
-	val, err := utils.GetAsFloat("10", 123)
+	val, err := GetAsFloat("10", 123)
 	assert.Equal(val, 10.0)
 	assert.Nil(err)
 
-	val, err = utils.GetAsFloat("10.21", 123)
+	val, err = GetAsFloat("10.21", 123)
 	assert.Equal(val, 10.21)
 	assert.Nil(err)
 
@@ -61,7 +61,7 @@ func TestGetFloat(t *testing.T) {
 	assert.Equal(val, 123.0)
 	assert.NotNil(err)
 
-	val, err = utils.GetAsFloat(12.123, 123)
+	val, err = GetAsFloat(12.123, 123)
 	assert.Equal(val, 12.123)
 	assert.Nil(err)
 }
@@ -69,13 +69,13 @@ func TestGetFloat(t *testing.T) {
 func TestGetString(t *testing.T) {
 	assert := assert.New(t)
 
-	val := utils.GetAsString("10")
+	val := GetAsString("10")
 	assert.Equal(val, "10")
 
-	val = utils.GetAsString(10)
+	val = GetAsString(10)
 	assert.equal(val, "10")
 
-	val = utils.GetAsString(10.123)
+	val = GetAsString(10.123)
 	assert.equal(val, "10.123")
 }
 
@@ -88,17 +88,17 @@ func TestGetAsMap(t *testing.T) {
 		"runtimeenv": "dev",
 		"region":     "uswest1-devc",
 	}
-	assert.Equal(utils.GetAsMap(stringToParse), expectedValue)
+	assert.Equal(GetAsMap(stringToParse), expectedValue)
 
 	// Test if map[string]interface{} can be converted to map[string]string
 	interfaceMapToParse := make(map[string]interface{})
 	interfaceMapToParse["foo"] = "bar"
 	interfaceMapToParse["alice"] = "bob"
 
-	actualValue, err := utils.GetAsMap(interfaceMapToParse)
+	actualValue, err := GetAsMap(interfaceMapToParse)
 	assert.Equal(actualValue, expectedValue)
 
-	actualValue, err = utils.GetAsMap(123)
+	actualValue, err = GetAsMap(123)
 	assert.NotNil(err)
 }
 
@@ -108,13 +108,13 @@ func TestGetAsSlice(t *testing.T) {
 	// Test if string array can be converted to []string
 	stringToParse := "[\"baz\", \"bat\"]"
 	expectedValue := []string{"baz", "bat"}
-	assert.Equal(utils.GetAsSlice(stringToParse), expectedValue)
+	assert.Equal(GetAsSlice(stringToParse), expectedValue)
 
 	sliceToParse := []string{"baz", "bat"}
-	actualValue, err := utils.GetAsSlice(sliceToParse)
+	actualValue, err := GetAsSlice(sliceToParse)
 	assert.Equal(actualValue, expectedValue)
 
-	actualValue, err = utils.GetAsSlice(123)
+	actualValue, err = GetAsSlice(123)
 	assert.NotNil(err)
 }
 
@@ -128,10 +128,10 @@ func TestGetAsSliceFromYAML(t *testing.T) {
 	if err == nil {
 		temp := data.(map[string]interface{})
 
-		res, err := utils.GetAsSlice(temp["listOfStrings"])
+		res, err := GetAsSlice(temp["listOfStrings"])
 		assert.Equal(t, []string{"a", "b", "c"}, res)
 
-		res, err = utils.GetAsSlice(123)
+		res, err = GetAsSlice(123)
 		assert.NotNil(err)
 	}
 }

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -7,81 +7,71 @@ import (
 )
 
 func TestGetBool(t *testing.T) {
-	assert := assert.New(t)
-
 	val, err := GetAsBool("false", true)
-	assert.Equal(val, false)
+	assert.Equal(t, val, false)
 	assert.Nil(t, err)
 
 	val, err = GetAsBool("notabool", false)
-	assert.Equal(val, false)
+	assert.Equal(t, val, false)
 	assert.NotNil(t, err)
 
 	val, err = GetAsBool(true, false)
-	assert.Equal(val, true)
+	assert.Equal(t, val, true)
 	assert.Nil(t, err)
 
 	val, err = GetAsBool("True", false)
-	assert.Equal(val, true)
+	assert.Equal(t, val, true)
 	assert.Nil(t, err)
 }
 
 func TestGetInt(t *testing.T) {
-	assert := assert.New(t)
-
 	val, err := GetAsInt("10", 123)
-	assert.Equal(val, 10)
+	assert.Equal(t, val, 10)
 	assert.Nil(t, err)
 
 	val, err = GetAsInt("notanint", 123)
-	assert.Equal(val, 123)
+	assert.Equal(t, val, 123)
 	assert.NotNil(t, err)
 
 	val, err = GetAsInt(12.123, 123)
-	assert.Equal(val, 12)
+	assert.Equal(t, val, 12)
 	assert.Nil(t, err)
 
 	val, err = GetAsInt(12, 123)
-	assert.Equal(val, 12)
+	assert.Equal(t, val, 12)
 	assert.Nil(t, err)
 }
 
 func TestGetFloat(t *testing.T) {
-	assert := assert.New(t)
-
 	val, err := GetAsFloat("10", 123)
-	assert.Equal(val, 10.0)
+	assert.Equal(t, val, 10.0)
 	assert.Nil(t, err)
 
 	val, err = GetAsFloat("10.21", 123)
-	assert.Equal(val, 10.21)
+	assert.Equal(t, val, 10.21)
 	assert.Nil(t, err)
 
 	val, err = GetAsFloat("notafloat", 123)
-	assert.Equal(val, 123.0)
+	assert.Equal(t, val, 123.0)
 	assert.NotNil(t, err)
 
 	val, err = GetAsFloat(12.123, 123)
-	assert.Equal(val, 12.123)
+	assert.Equal(t, val, 12.123)
 	assert.Nil(t, err)
 }
 
 func TestGetString(t *testing.T) {
-	assert := assert.New(t)
-
 	val := GetAsString("10")
-	assert.Equal(val, "10")
+	assert.Equal(t, val, "10")
 
 	val = GetAsString(10)
-	assert.Equal(val, "10")
+	assert.Equal(t, val, "10")
 
 	val = GetAsString(10.123)
-	assert.Equal(val, "10.123")
+	assert.Equal(t, val, "10.123")
 }
 
 func TestGetAsMap(t *testing.T) {
-	assert := assert.New(t)
-
 	// Test if string can be converted to map[string]string
 	stringToParse := "{\"foor\" : \"bar\", \"alice\":\"bob\"}"
 	expectedValue := map[string]string{
@@ -104,8 +94,6 @@ func TestGetAsMap(t *testing.T) {
 }
 
 func TestGetAsSlice(t *testing.T) {
-	assert := assert.New(t)
-
 	// Test if string array can be converted to []string
 	stringToParse := "[\"baz\", \"bat\"]"
 	expectedValue := []string{"baz", "bat"}

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -73,10 +73,10 @@ func TestGetString(t *testing.T) {
 
 func TestGetAsMap(t *testing.T) {
 	// Test if string can be converted to map[string]string
-	stringToParse := "{\"foor\" : \"bar\", \"alice\":\"bob\"}"
+	stringToParse := "{\"foo\" : \"bar\", \"alice\":\"bob\"}"
 	expectedValue := map[string]string{
-		"runtimeenv": "dev",
-		"region":     "uswest1-devc",
+		"foo":   "bar",
+		"alice": "bob",
 	}
 	actualValue, err := GetAsMap(stringToParse)
 	assert.Equal(t, actualValue, expectedValue)

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -116,7 +116,7 @@ func TestGetAsSliceFromYAML(t *testing.T) {
 	assert.Nil(t, err)
 
 	if err == nil {
-		temp := data.(map[string]interface{})
+		temp := data
 
 		res, err := GetAsSlice(temp["listOfStrings"])
 		assert.Equal(t, []string{"a", "b", "c"}, res)

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -109,7 +109,7 @@ func TestGetAsSlice(t *testing.T) {
 }
 
 func TestGetAsSliceFromYAML(t *testing.T) {
-	var data interface{}
+	var data map[string]interface{}
 	yamlString := []byte(`{"listOfStrings": ["a", "b", "c"]}`)
 
 	err := yaml.Unmarshal(yamlString, &data)

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -11,19 +11,19 @@ func TestGetBool(t *testing.T) {
 
 	val, err := GetAsBool("false", true)
 	assert.Equal(val, false)
-	assert.Nil(err)
+	assert.Nil(t, err)
 
 	val, err = GetAsBool("notabool", false)
 	assert.Equal(val, false)
-	assert.NotNil(err)
+	assert.NotNil(t, err)
 
 	val, err = GetAsBool(true, false)
 	assert.Equal(val, true)
-	assert.Nil(err)
+	assert.Nil(t, err)
 
 	val, err = GetAsBool("True", false)
 	assert.Equal(val, true)
-	assert.Nil(err)
+	assert.Nil(t, err)
 }
 
 func TestGetInt(t *testing.T) {
@@ -31,19 +31,19 @@ func TestGetInt(t *testing.T) {
 
 	val, err := GetAsInt("10", 123)
 	assert.Equal(val, 10)
-	assert.Nil(err)
+	assert.Nil(t, err)
 
 	val, err = GetAsInt("notanint", 123)
 	assert.Equal(val, 123)
-	assert.NotNil(err)
+	assert.NotNil(t, err)
 
 	val, err = GetAsInt(12.123, 123)
 	assert.Equal(val, 12)
-	assert.Nil(err)
+	assert.Nil(t, err)
 
 	val, err = GetAsInt(12, 123)
 	assert.Equal(val, 12)
-	assert.Nil(err)
+	assert.Nil(t, err)
 }
 
 func TestGetFloat(t *testing.T) {
@@ -51,19 +51,19 @@ func TestGetFloat(t *testing.T) {
 
 	val, err := GetAsFloat("10", 123)
 	assert.Equal(val, 10.0)
-	assert.Nil(err)
+	assert.Nil(t, err)
 
 	val, err = GetAsFloat("10.21", 123)
 	assert.Equal(val, 10.21)
-	assert.Nil(err)
+	assert.Nil(t, err)
 
-	val, err = confir.GetAsFloat("notafloat", 123)
+	val, err = GetAsFloat("notafloat", 123)
 	assert.Equal(val, 123.0)
-	assert.NotNil(err)
+	assert.NotNil(t, err)
 
 	val, err = GetAsFloat(12.123, 123)
 	assert.Equal(val, 12.123)
-	assert.Nil(err)
+	assert.Nil(t, err)
 }
 
 func TestGetString(t *testing.T) {
@@ -73,10 +73,10 @@ func TestGetString(t *testing.T) {
 	assert.Equal(val, "10")
 
 	val = GetAsString(10)
-	assert.equal(val, "10")
+	assert.Equal(val, "10")
 
 	val = GetAsString(10.123)
-	assert.equal(val, "10.123")
+	assert.Equal(val, "10.123")
 }
 
 func TestGetAsMap(t *testing.T) {
@@ -88,18 +88,19 @@ func TestGetAsMap(t *testing.T) {
 		"runtimeenv": "dev",
 		"region":     "uswest1-devc",
 	}
-	assert.Equal(GetAsMap(stringToParse), expectedValue)
+	actualValue, err := GetAsMap(stringToParse)
+	assert.Equal(actualValue, expectedValue)
 
 	// Test if map[string]interface{} can be converted to map[string]string
 	interfaceMapToParse := make(map[string]interface{})
 	interfaceMapToParse["foo"] = "bar"
 	interfaceMapToParse["alice"] = "bob"
 
-	actualValue, err := GetAsMap(interfaceMapToParse)
+	actualValue, err = GetAsMap(interfaceMapToParse)
 	assert.Equal(actualValue, expectedValue)
 
 	actualValue, err = GetAsMap(123)
-	assert.NotNil(err)
+	assert.NotNil(t, err)
 }
 
 func TestGetAsSlice(t *testing.T) {
@@ -108,14 +109,15 @@ func TestGetAsSlice(t *testing.T) {
 	// Test if string array can be converted to []string
 	stringToParse := "[\"baz\", \"bat\"]"
 	expectedValue := []string{"baz", "bat"}
-	assert.Equal(GetAsSlice(stringToParse), expectedValue)
+	actualValue, err := GetAsSlice(stringToParse)
+	assert.Equal(actualValue, expectedValue)
 
 	sliceToParse := []string{"baz", "bat"}
-	actualValue, err := GetAsSlice(sliceToParse)
+	actualValue, err = GetAsSlice(sliceToParse)
 	assert.Equal(actualValue, expectedValue)
 
 	actualValue, err = GetAsSlice(123)
-	assert.NotNil(err)
+	assert.NotNil(t, err)
 }
 
 func TestGetAsSliceFromYAML(t *testing.T) {
@@ -132,6 +134,6 @@ func TestGetAsSliceFromYAML(t *testing.T) {
 		assert.Equal(t, []string{"a", "b", "c"}, res)
 
 		res, err = GetAsSlice(123)
-		assert.NotNil(err)
+		assert.NotNil(t, err)
 	}
 }

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -1,7 +1,6 @@
 package utils
 
 import (
-	utils "github.com/bobtfish/AWSnycast/utils"
 	"github.com/stretchr/testify/assert"
 	"gopkg.in/yaml.v2"
 	"testing"


### PR DESCRIPTION
This tackles #6 where we want to make the healthcecks config
a map of interfaces. This makes it work in a way where we can really
pass in config more flexibly and have the utility function take care of
the respective conversions.